### PR TITLE
Make Rtttl.stopTone public

### DIFF
--- a/src/Rtttl.h
+++ b/src/Rtttl.h
@@ -26,6 +26,7 @@ public:
         Rtttl(int buzzerPin);
         void play(_FLASH_STRING songInPlay);
         void updateMelody();
+        void stopTone();
 protected:
   #define NOTE_B0  31
   #define NOTE_C1  33
@@ -153,7 +154,6 @@ protected:
         unsigned long melodyLoopCounter;
 
       void playMelody();
-      void stopTone();
       void getNextNote();
 };
 


### PR DESCRIPTION
It's useful to have a way of resetting Rtttl instead of having to wait for the entire melody to finish. If I tried switching with `Rtttl.play` it made a garbled mess of the next tune I tried playing.

When making `stopTone` public, it worked a whole lot better. From what I can see, it doesn't really do anything that can be harmful, so making it public shouldn't be a problem